### PR TITLE
Remove lyft.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Some sources:
 - patreon.com
 - producthunt.com
 - bitpay.com
+- 
 - irccloud.com
+- betterment.com
 
 ## Alexa Top 10,000 affected sites:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Some sources:
 - fastmail.com (does not proxy TLS, probably safe from this attack)
 - reddit.com
 - uber.com
-- lyft.com
 - upwork.com
 - codepen.io
 - medium.com
@@ -79,7 +78,6 @@ Some sources:
 - producthunt.com
 - bitpay.com
 - irccloud.com
-- betterment.com
 
 ## Alexa Top 10,000 affected sites:
 


### PR DESCRIPTION
We don't use Cloudflare:

```
$ shasum -a 1 sorted_unique_cf.txt
22494e6b263a8c80f6048a0bf537eb07b3331c41  sorted_unique_cf.txt
$ grep -c '^lyft\.com' sorted_unique_cf.txt
0
```