### PR TITLE
Noting fastmail.com not affected

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can also ping me on twitter [@theSquashSH](https://twitter.com/thesquashsh) 
 - localbitcoins.com
 - kraken.com
 - 23andme.com
-- fastmail.com (does not proxy TLS, probably safe from this attack)
+- fastmail.com ([not affected](https://twitter.com/FastMail/status/834939787924557824), [#2](https://news.ycombinator.com/item?id=13720050))
 - 1password.com ([not affected](https://discussions.agilebits.com/discussion/comment/356869/#Comment_356869))
 
 ## Alexa Top 10,000 affected sites:


### PR DESCRIPTION
Not affected. FastMail DNS is proxied through Cloudflare [Virtual DNS](https://www.cloudflare.com/dns/virtual-dns/), but we do not use their web/TLS infrastructure at all.