### PR TITLE
Remove reddit.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Also, a list of some [iOS apps](https://www.nowsecure.com/blog/2017/02/23/cloudf
 - news.ycombinator.com
 - producthunt.com
 - medium.com
-- reddit.com
 - 4chan.org
 - yelp.com
 - okcupid.com


### PR DESCRIPTION
We moved reddit.com to Fastly shortly before the vulnerable period for CloudFlare.