### PR TITLE
Create cloudbleed_domains.txt

### DIFF
--- a/cloudbleed_domains.txt
+++ b/cloudbleed_domains.txt
@@ -1,0 +1,5 @@
+dmsprod.shrbt.com
+gateway.discord.gg
+secure.meetup.com
+www.kiwidisk.com
+www.taxslayer.com

--- a/cloudbleed_domains.txt
+++ b/cloudbleed_domains.txt
@@ -1,3 +1,4 @@
+android-cdn-api.fitbit.com
 dmsprod.shrbt.com
 gateway.discord.gg
 secure.meetup.com


### PR DESCRIPTION
List of domains affected by Cloudbleed.

Found leaked requests headers in Google cache, e.g.

```
Set-SSL-Name: android-cdn-api.fitbit.com
Set-SSL-Name: dmsprod.shrbt.com
Set-SSL-Name: gateway.discord.gg
Set-SSL-Name: secure.meetup.com
Set-SSL-Name: www.kiwidisk.com
Set-SSL-Name: www.taxslayer.com
```

Searched on scrapped HTML files with `cat | grep Set-SSL-Name | ruby -e "puts STDIN.each_line.to_a.join.scan(/Set-SSL-Name: [a-zA-Z0-9._-]+/)" | sort | uniq`