### PR TITLE
Mark avito.ru as not affected

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Also, a list of some [iOS apps](https://www.nowsecure.com/blog/2017/02/23/cloudf
 - avaz.ba
 - avazutracking.net
 - avito.ma
-- avito.ru
+- avito.ru (confirmed by @toogle from Avito.ru as not affected)
 - avn.info.ve
 - azertag.com
 - aznews.az


### PR DESCRIPTION
We're only using CF as a DNS provider and a CDN for static content (mainly, images). Here are a few examples:

```
$ host www.avito.ru  # our main domain
www.avito.ru has address 185.89.12.132
$ host www.avito.st  # our dedicated domain for static content
www.avito.st has address 104.16.152.135
www.avito.st has address 104.16.153.135
www.avito.st has IPv6 address 2400:cb00:2048:1::6810:9887
www.avito.st has IPv6 address 2400:cb00:2048:1::6810:9987
$ host 50.img.avito.st  # one of image domains, we have a hundred of them (00-99)
50.img.avito.st has address 104.16.38.20
50.img.avito.st has address 104.16.39.20
50.img.avito.st has IPv6 address 2400:cb00:2048:1::6810:2714
50.img.avito.st has IPv6 address 2400:cb00:2048:1::6810:2614
```

We terminate TLS for the main domain and all its subdomains within our DC, so Avito.ru is definitely unaffected by CF data leak.