### PR TITLE
Remove tinhte.vn from README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,7 +1189,6 @@ Also, a list of some [iOS apps](https://www.nowsecure.com/blog/2017/02/23/cloudf
 - tickld.com
 - tielabs.com
 - tineye.com
-- tinhte.vn
 - tipsandtricks-hq.com
 - tmart.com
 - tn.com.ar


### PR DESCRIPTION
Since last year we had been only using Cloudflare's DNS services. All traffic goes straight to our server since then and we are not affected by this CloudFlare incident. We would prefer to have our site removed from the README list.

Thank you very much.