### PR TITLE
Remove: trojmiasto.pl (DNS only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,7 +1224,6 @@ Also, a list of some [iOS apps](https://www.nowsecure.com/blog/2017/02/23/cloudf
 - traidnt.net
 - tribune.com.pk
 - trndsys.co
-- trojmiasto.pl
 - trueactivist.com
 - truthaboutabs.com
 - tubeplus.me


### PR DESCRIPTION
We do not use Cloudflare CDN, only DNS. We use the CDN for a second tier site, but that site does not include login forms etc. and generally does not use customer data.