### PR TITLE
Add: technicpack.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Additionally, you can check out [#37](https://github.com/pirate/sites-using-clou
 - tfl.gov.uk
 - account.leagueoflegends.com
 - myaccount.nytimes.com
+- technicpack.net
 - namecheap.com ([no evidence of compromised data](https://status.namecheap.com/archives/30660))
 - discordapp.com ([affected](https://blog.discordapp.com/safety-jim-psa-cloudflare-security-issue-77a4ecc48298))
 - glassdoor.com ([no evidence of compromised data](https://twitter.com/Glassdoor/status/835238343822589952))


### PR DESCRIPTION
technicpack.net is a Minecraft Modpack hosting service and in order to post a modpack, you need to use an account to do so. I don't know if it was affected but it should be added because it might have been affected.

Before submitting your pull-request:

 - name of the pull request should be "Add: domain, domain, domain (proxy + DNS)" or "Remove: domain (static), domain (DNS only), domain (static)"
 - do not ask for removal of actually affected websites (any websites using cloudflare reverse proxy)

### HOW TO REMOVE YOUR SITE
1. Verify the site is static and contains no user or sensitive data (I will remove it immediately once I confirm)  

OR  

1. Verify ownership, send me an email from @yourdomain.com, post a random nonce on the domain, or provide keybase proof
2. Verify you did not use the Cloudflare proxy service during the affected period 
