### PR TITLE
Remove fitbit.com per #157

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Additionally, you can check out [#37](https://github.com/pirate/sites-using-clou
 - ziprecruiter.com
 - glassdoor.com
 - pastebin.com
-- fitbit.com
 - discordapp.com
 - change.org
 - feedly.com


### PR DESCRIPTION
Doesn't use Cloudflare presently, and didn't within the relevant
timeframe.

Signed-off-by: Paul Buonopane <paul@namepros.com>