### PR TITLE
mydigitallife.info isn't affected by this

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ Check out [our wiki page](https://github.com/pirate/sites-using-cloudflare/wiki/
 - [mybb.com](http://mybb.com)
 - [mybroadband.co.za](http://mybroadband.co.za)
 - [mydealz.de](http://mydealz.de)
-- [mydigitallife.info](http://mydigitallife.info)
+- [mydigitallife.info](http://mydigitallife.info) ([confirmed by Daz](https://forums.mydigitallife.info/threads/73308-List-of-Sites-possibly-affected-by-Cloudflare-s-Cloudbleed-HTTPS-Traffic-Leak?p=1321465&viewfull=1#post1321465) from MDL as not affected)
 - [myegy.com](http://myegy.com)
 - [mygully.com](http://mygully.com)
 - [mylikes.com](http://mylikes.com)


### PR DESCRIPTION
> MDL shouldn't be affected by this since we didn't have the settings enabled that caused the problem. We've also received an email from Cloudflare to confirm this.
> 
> It should be made clear that the list of sites using Cloudflare doesn't reflect who was and wasn't affected. Of course you should change your passwords anyway, just to be safe.

Source (you need to login to see this that's why I copy & paste the content over here):
https://forums.mydigitallife.info/threads/73308-List-of-Sites-possibly-affected-by-Cloudflare-s-Cloudbleed-HTTPS-Traffic-Leak?p=1321465&viewfull=1#post1321465