### PR TITLE
Update: authy.com (no data found in caches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check out [our wiki page](https://github.com/pirate/sites-using-cloudflare/wiki/
 
 ## Notable Sites
 
-- [authy.com](http://authy.com)
+- [authy.com](http://authy.com) ([no leaked data found in several search engine caches](https://www.authy.com/blog/security-notice-authy-response-to-cloudflare-cloudbleed-incident/))
 - [coinbase.com](http://coinbase.com)
 - [bitcoin.de](http://bitcoin.de)
 - [betterment.com](http://betterment.com)


### PR DESCRIPTION
authy.com published a blog post on Fri 24th Feb detailing their work
with CloudFlare and that at the time of writing there had been no
evidence of leaked data.

Before submitting your pull-request:

 - name of the pull request should be "Add: domain, domain, domain (proxy + DNS)" or "Remove: domain (static), domain (DNS only), domain (static)"
 - do not ask for removal of actually affected websites (any websites using cloudflare reverse proxy)

### HOW TO REMOVE YOUR SITE
1. Verify the site is static and contains no user or sensitive data (I will remove it immediately once I confirm)  

OR  

1. Verify ownership, send me an email from @yourdomain.com, post a random nonce on the domain, or provide keybase proof
2. Verify you did not use the Cloudflare proxy service during the affected period 
