### PR TITLE
Remove: kanui.com.br, parceriakanui.com.br

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,6 @@ Check out [our wiki page](https://github.com/pirate/sites-using-cloudflare/wiki/
 - [jvzoo.com](http://jvzoo.com)
 - [kaban.tv](http://kaban.tv)
 - [kalahari.com](http://kalahari.com)
-- [kanui.com.br](http://kanui.com.br)
 - [karnaval.com](http://karnaval.com)
 - [katproxy.com](http://katproxy.com)
 - [keep2share.cc](http://keep2share.cc)


### PR DESCRIPTION
Used PROXY

"Segue posicionamento da Kanui enviado ao site Olhar Digital:
 
A Kanui esclarece que o problema relatado com a Cloudflare não afetou seus sistemas e nenhum dado foi exposto, uma vez que o serviço atingido pela vulnerabilidade não era utilizado pela empresa. Aparecemos na lista de clientes da Cloudflare por usarmos outros serviços que não trafegam dados de login e senha, portanto, não colocam em risco informações dos nossos consumidores.
 
Em e-mail enviado à Kanui, o provedor confirma que a mesma não foi afetada pelo problema detectado.
 
Reforçamos que a segurança e sigilo de informação são nossos compromissos para garantir uma experiência de compra segura a todos os clientes."

https://olhardigital.uol.com.br/fique_seguro/noticia/troque-imediatamente-as-suas-senhas-destes-servicos/66422

------------------------------------------------------------------------------------------------

Before submitting your pull-request:

 - name of the pull request should be "Add: domain, domain, domain (proxy + DNS)" or "Remove: domain (static), domain (DNS only), domain (static)"
 - do not ask for removal of actually affected websites (any websites using cloudflare reverse proxy)

### HOW TO REMOVE YOUR SITE
1. Verify the site is static and contains no user or sensitive data (I will remove it immediately once I confirm)  

OR  

1. Verify ownership, send me an email from @yourdomain.com, post a random nonce on the domain, or provide keybase proof
2. Verify you did not use the Cloudflare proxy service during the affected period 
