### PR TITLE
Remove: upwork.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Check out [our wiki page](https://github.com/pirate/sites-using-cloudflare/wiki/
 
 ## Alexa Top 10,000 on Cloudflare DNS:
 
-- [upwork.com](http://upwork.com)
 - [codepen.io](http://codepen.io)
 - [fiverr.com](http://fiverr.com)
 - [thepiratebay.org](http://thepiratebay.org)


### PR DESCRIPTION
Upwork.com was not affected by the Cloudflare leak. Official company statement here: https://www.upwork.com/blog/2017/02/cloudflare/. We also tweeted per instructions: https://twitter.com/shoshd/status/836257839224008704. Thanks!

Before submitting your pull-request:

 - name of the pull request should be "Add: domain, domain, domain (proxy + DNS)" or "Remove: domain (static), domain (DNS only), domain (static)"
 - do not ask for removal of actually affected websites (any websites using cloudflare reverse proxy)

### HOW TO REMOVE YOUR SITE
1. Verify the site is static and contains no user or sensitive data (I will remove it immediately once I confirm)  

OR  

1. Verify ownership, send me an email from @yourdomain.com, post a random nonce on the domain, or provide keybase proof
2. Verify you did not use the Cloudflare proxy service during the affected period 
